### PR TITLE
Adding try/catch around utf-8 string decoding

### DIFF
--- a/pyrpm/rpm.py
+++ b/pyrpm/rpm.py
@@ -103,7 +103,15 @@ class Entry(object):
             if char == b'\x00':  # read until '\0'
                 break
             string += char
-        return string.decode('utf-8')
+
+        # not all UTF-8 is valid and we should catch any errors processing those as ultimately
+        # a strange character is acceptable
+        try: 
+            returnstring = string.decode('utf-8')
+        except UnicodeError:
+            returnstring = string
+
+        return returnstring
 
     def _read_string_array(self, store, data_count):
         ''' read a array of string entries


### PR DESCRIPTION
It appears that bad UTF-8 encoding on metadata in packages can break reading in a package. Specifically, you can see what I'm referring to here:

https://gist.github.com/jmdarr/d33e3101c392ca82dc2d

Using less with proper UTF-8 decoding I see this as the bad UTF-8 character:
[jdarr@codebox ~]$ rpm -qpil --changelog system-config-kickstart-2.8.6.5-1.el6.noarch.rpm | less
_snip_
- Mon Sep 14 2009 Ville Skytt<E4> ville.skytta@iki.fi - 2.8.2-2

While this code doesn't fix the UTF-8 error, it does skip over it and at least allow the package to be read in as a YumPackage.
