### PR TITLE
Attempt to use C backend for xml parsing if available

### DIFF
--- a/pyrpm/tools/createrepo.py
+++ b/pyrpm/tools/createrepo.py
@@ -2,7 +2,11 @@ import gzip
 import hashlib
 import os
 import os.path
-from xml.etree import ElementTree
+# First attempt to use the C backend if available if not fall back to python backend
+try:
+    from xml.etree import cElementTree as ElementTree
+except:
+    from xml.etree import ElementTree
 
 # try to import the best StringIO
 from StringIO import StringIO

--- a/pyrpm/yum.py
+++ b/pyrpm/yum.py
@@ -1,4 +1,8 @@
-from xml.etree.ElementTree import Element
+# First attempt to use the C backend if available if not fall back to python backend
+try:
+    from xml.etree.cElementTree import Element
+except:
+    from xml.etree.ElementTree import Element
 
 from rpm import RPM
 


### PR DESCRIPTION
The C backend for xml parsing is both faster and uses far less RAM then the python backend. It should be used if available.
