### PR TITLE
All user-defined exceptions should also be derived from "Exception"

### DIFF
--- a/pyrpm/rpm.py
+++ b/pyrpm/rpm.py
@@ -227,7 +227,7 @@ class Header(HeaderBase):
     }
 
 
-class RPMError(BaseException):
+class RPMError(Exception):
     pass
 
 


### PR DESCRIPTION
https://docs.python.org/2/library/exceptions.html#exceptions.Exception

So I'm not 100% sure why this was causing issues for me as BaseException however in a multiprocess app that I wrote that uses pyrpm whenever a RPMError exception was caught within a subprocess of my main app it would hang the process.
