### PR TITLE
Adding proper location href attribute in the primary xml file

### DIFF
--- a/pyrpm/yum.py
+++ b/pyrpm/yum.py
@@ -26,7 +26,7 @@ class YumPackage(RPM):
         ele.append(element('{http://linux.duke.edu/metadata/common}url', text=self.header.url))
         ele.append(element('{http://linux.duke.edu/metadata/common}time', {'file': str(self.header.build_time), 'build': str(self.header.build_time)}))
         ele.append(element('{http://linux.duke.edu/metadata/common}size', {'package': str(self.filesize), 'installed': str(sum([file.size for file in self.filelist])), 'archive': str(self.header.archive_size)}))
-        ele.append(element('{http://linux.duke.edu/metadata/common}location', {'href': self.canonical_filename}))
+        ele.append(element('{http://linux.duke.edu/metadata/common}location', {'href': self.rpmfile.name}))
 
     def _xml_format_items(self, ele):
         ef = element('{http://linux.duke.edu/metadata/common}format')


### PR DESCRIPTION
Adding a '_canonical name_' does not add the absolute path of the rpm file to the location attribute. This results in the packages not being available when queried using yum client.

This is seen when the rpm files are kept within sub folders. Have observed this on Windows.

To reproduce this issue have a test python app that takes a base folder, recurses the folders and adds any rpm files found within the sub folders.

For eg: say we have a base folder called c:\repo. This folder contains sub folder called "tsp", which contains some rpm file such as expat-2.1.0-8.el7.i686.rpm. Suppose the test app takes the base folder c:\repo and recursively goes through the sub folder and adds the rpm.

Now looking at the generated primary.xml file, it is seen that 
<location href="expat-2.1.0-8.el7.i686.rpm" />

When the c:\repo folder is served from a webserver, when yum client tries to install expat, the path is given as just \expat-2.1.0-8.el7.i686.rpm which results in 404.

The location must be as below with complete path 
<location href="**C:\repo\tsp\**expat-2.1.0-8.el7.i686.rpm" />

Not sure if this is the right way to fix the path, comments welcome.